### PR TITLE
Try to use -c -L to print the hash result when uploaded...

### DIFF
--- a/Backups/upload_logs_gsutil_gbucket.sh
+++ b/Backups/upload_logs_gsutil_gbucket.sh
@@ -33,7 +33,7 @@ do
     for upload in $(find $log/*.$fformat -mtime +$days_older)
     do
         file=$(echo $upload | awk -F/ '{print $NF}')
-        gsutil cp "$upload" "gs://$gbucket/$folder/$service/"
+        gsutil cp -c -L "$upload" "gs://$gbucket/$folder/$service/"
         hash_local=$(gsutil hash "$upload" | grep crc32c | awk '{print $3}')
         hash_bucket=$(gsutil ls -L "gs://$gbucket/$folder/$service/$file" | grep crc32c | awk '{print $3}')
         total_files=$(($total_files + 1))


### PR DESCRIPTION
 -L <file>: 
Outputs a manifest log file with detailed information about each item that was copied. This manifest contains the following information for each item, like hash, upload id, etc...

-c: If an error occurs, continue to attempt to copy the remaining files. If any copies were unsuccessful, gsutil’s exit status will be non-zero even if this flag is set.